### PR TITLE
Make determinism hybrid

### DIFF
--- a/src/path.py
+++ b/src/path.py
@@ -13,6 +13,10 @@ class Path(list):
         self.path = []
     
     @staticmethod
+    def generate_path(X_0: Position, X_1: Position, speed: float = 1):
+        return []
+    
+    @staticmethod
     def interpolate(X_0: Position, X_1: Position, speed: float = 1) -> List[Position]:
         x_distance = abs(X_1.x - X_0.x)
         y_distance = abs(X_1.y - X_0.y)

--- a/src/path.py
+++ b/src/path.py
@@ -14,7 +14,7 @@ class Path(list):
     
     @staticmethod
     def generate_path(X_0: Position, X_1: Position, speed: float = 1):
-        return []
+        return Path.interpolate(X_0, X_1, speed)
     
     @staticmethod
     def interpolate(X_0: Position, X_1: Position, speed: float = 1) -> List[Position]:

--- a/src/path.py
+++ b/src/path.py
@@ -1,20 +1,54 @@
-from math import cos, pi, sin
-from typing import List, Tuple
+from math import ceil, cos, sin
+from typing import List
 
 from src.position import Position
 
 
-class RightAngleException(Exception):
-    pass
-
-
 class Path(list):
-    def __init__(self):
-        self.path = []
-    
+    CORNER_RADIUS = 3
+
+    def __init__(self, X_0: Position, X_1: Position, speed: float):
+        self.X_0 = X_0
+
+        self.pre_calculated_path = self.pre_calculate_path(
+            self.X_0,
+            X_1,
+            speed
+        )
+
     @staticmethod
-    def generate_path(X_0: Position, X_1: Position, speed: float = 1):
-        return Path.interpolate(X_0, X_1, speed)
+    def pre_calculate_path(X_0, X_1, speed):
+        AB = Path.calculate_AB(X_0, X_1)
+        X_a = AB[0]
+
+        if len(AB) == 1:
+            return [X_a]
+        
+        X_b = AB[1]
+        
+        corner = Path.generate_corner(X_a, X_b, speed)
+        exit = Path.interpolate(X_b, X_1, speed)
+
+        return [*corner[:-1], *exit]
+        
+    @staticmethod
+    def calculate_AB(X_0: Position, X_1: Position):
+        if X_0.theta == X_1.theta:
+            return [X_1]
+
+        X_a = Position(
+            X_0.x + (abs(X_1.x - X_0.x) - Path.CORNER_RADIUS) * cos(X_0.theta),
+            X_0.y + (abs(X_1.y - X_0.y) - Path.CORNER_RADIUS) * sin(X_0.theta),
+            X_0.theta
+        )
+        
+        X_b = Position(
+            X_1.x + (Path.CORNER_RADIUS - abs(X_1.x - X_0.x)) * cos(X_1.theta),
+            X_1.y + (Path.CORNER_RADIUS - abs(X_1.y - X_0.y)) * sin(X_1.theta),
+            X_1.theta
+        )
+
+        return [X_a, X_b]
     
     @staticmethod
     def interpolate(X_0: Position, X_1: Position, speed: float = 1) -> List[Position]:
@@ -45,15 +79,15 @@ class Path(list):
         return positions
     
     @staticmethod
-    def generate_corner(X_a: Position, X_b: Position, n_segments: int = 10) -> List[Position]:
+    def generate_corner(X_a: Position, X_b: Position, speed: float) -> List[Position]:
+        corner_angle = abs(X_b.theta - X_a.theta)
+        corner_radius = abs(X_b.x - X_a.x)
+        L_corner = corner_angle * corner_radius
 
-        if n_segments == 0:
-            raise RightAngleException
-        
+        n_segments = ceil(L_corner / speed)
         n_positions = n_segments + 1
         
         thetas = [X_a.theta + ((X_b.theta- X_a.theta) / n_positions) * (i + 1) for i in range(n_positions)]
-        
         L_segment = (X_b.x - X_a.x) / sum([cos(theta) for theta in thetas])
 
         x_i = [X_a.x]

--- a/test/commons.py
+++ b/test/commons.py
@@ -12,5 +12,8 @@ def assert_position_equal(val: Position, exp: Position, places: int = 7):
 
 
 def assert_path_equal(val: Path, exp: Path, places: int = 7):
+    tc = unittest.TestCase()
+    tc.assertEqual(len(val), len(exp))
+
     for v, e in zip(val, exp):
         assert_position_equal(v, e, places=places)

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -1,7 +1,7 @@
 import unittest
 from math import cos, pi, sin
 
-from src.path import Path, RightAngleException
+from src.path import Path
 from src.position import Position
 
 from test.commons import assert_path_equal, assert_position_equal
@@ -88,93 +88,130 @@ class TestInterpolate(unittest.TestCase):
     
 
 class TestGenerateCorner(unittest.TestCase):
-    DEFAULT_DELTA_THETA = 0.14279
-    DEFAULT_L = 0.15406
+    SPEED = 0.3
+    N_POINTS = 7
+    L_SEGMENT = 0.253960
+    DELTA_THETA = 0.2243994
 
-    def test_no_corner(self):
-        X_0 = Position(0, 0, 0)
-        X_1 = Position(1, 1, 0.5 * pi)
-
-        with self.assertRaises(RightAngleException):
-            _ = Path.generate_corner(X_0, X_1, n_segments=0)
-    
     def test_1_segment(self):
         X_0 = Position(0, 0, 0)
         X_1 = Position(1, 1, 0.5 * pi)
+        speed = 2   # Make speed so high, that 1 frame already encompasses total corner length
 
-        corner = Path.generate_corner(X_0, X_1, n_segments=1)
+        corner = Path.generate_corner(X_0, X_1, speed)
         exp_p0 = Position(0, 0, 0.25 * pi)
         exp_p1 = Position(1, 1, 0.5 * pi)
 
         assert_path_equal(corner, [exp_p0, exp_p1])
 
-    def test_2_segments(self):
-        X_0 = Position(0, 0, 0)
-        X_1 = Position(1, 1, 0.5 * pi)
-        n_segments = 2
-
-        corner = Path.generate_corner(X_0, X_1, n_segments=n_segments)
-
-        exp_theta0 = (0.5 * pi) * (1 / 3)
-        exp_theta1 = (0.5 * pi) * (2 / 3)
-        exp_L = 1/(cos(exp_theta0) + cos(exp_theta1))
-        exp_p0 = Position(0, 0, exp_theta0)
-        exp_p1 = Position(exp_L * cos(exp_theta0), exp_L * sin(exp_theta0), exp_theta1)
-        exp_p2 = Position(1, 1, 0.5 * pi)
-
-        assert_path_equal(corner, [exp_p0, exp_p1, exp_p2])
-    
-    def test_10_segments(self):
+    def test_low_speed(self):
         X_0 = Position(0, 0, 0)
         X_1 = Position(1, 1, 0.5 * pi)
 
-        corner = Path.generate_corner(X_0, X_1)
+        corner = Path.generate_corner(X_0, X_1, self.SPEED)
 
         exp_p_1 = Position(
-            self.DEFAULT_L * cos(self.DEFAULT_DELTA_THETA), 
-            self.DEFAULT_L * sin(self.DEFAULT_DELTA_THETA), 
-            2 * self.DEFAULT_DELTA_THETA
+            self.L_SEGMENT * cos(self.DELTA_THETA),
+            self.L_SEGMENT * sin(self.DELTA_THETA),
+            2 * self.DELTA_THETA
         )
-        exp_p_m1 = Position(
-            1 - self.DEFAULT_L * sin(self.DEFAULT_DELTA_THETA),
-            1 - self.DEFAULT_L * cos(self.DEFAULT_DELTA_THETA),
-            0.5 * pi - self.DEFAULT_DELTA_THETA
+        exp_p_m2 = Position(
+            1 - self.L_SEGMENT * sin(self.DELTA_THETA),
+            1 - self.L_SEGMENT * cos(self.DELTA_THETA),
+            0.5 * pi - self.DELTA_THETA
         )
 
+        self.assertEqual(len(corner), self.N_POINTS)
         assert_position_equal(corner[1], exp_p_1, places=3)
-        assert_position_equal(corner[-2], exp_p_m1, places=3)
+        assert_position_equal(corner[-2], exp_p_m2, places=3)
+        assert_position_equal(corner[-1], X_1, places=3)
     
     def test_left_down_corner(self):
         X_0 = Position(1, 1, pi)
         X_1 = Position(0, 0, 1.5 * pi)
 
-        corner = Path.generate_corner(X_0, X_1)
+        corner = Path.generate_corner(X_0, X_1, self.SPEED)
 
         exp_p_1 = Position(
-            1 - self.DEFAULT_L * cos(self.DEFAULT_DELTA_THETA), 
-            1 - self.DEFAULT_L * sin(self.DEFAULT_DELTA_THETA), 
-            pi + 2 * self.DEFAULT_DELTA_THETA
+            1 - self.L_SEGMENT * cos(self.DELTA_THETA), 
+            1 - self.L_SEGMENT * sin(self.DELTA_THETA), 
+            pi + 2 * self.DELTA_THETA
         )
         exp_p_m1 = Position(
-            self.DEFAULT_L * sin(self.DEFAULT_DELTA_THETA),
-            self.DEFAULT_L * cos(self.DEFAULT_DELTA_THETA),
-            1.5 * pi - self.DEFAULT_DELTA_THETA
+            self.L_SEGMENT * sin(self.DELTA_THETA),
+            self.L_SEGMENT * cos(self.DELTA_THETA),
+            1.5 * pi - self.DELTA_THETA
         )
 
         assert_position_equal(corner[1], exp_p_1, places=3)
         assert_position_equal(corner[-2], exp_p_m1, places=3)
-    
 
-class TestPath(unittest.TestCase):
+
+class TestCalculateAB(unittest.TestCase):
     def test_straight_path(self):
         X_0 = Position(0, 0, 0)
         X_1 = Position(10, 0, 0)
 
-        path = Path.generate_path(X_0, X_1)
+        AB = Path.calculate_AB(X_0, X_1)
 
-        exp_path = [Position(i, 0, 0) for i in range(11)]
+        self.assertEqual(len(AB), 1)
+        assert_position_equal(AB[0], X_1)
+        
+    def test_corner_right_up(self):
+        X_0 = Position(2, 0, 0)
+        X_1 = Position(8, 8, 0.5 * pi)
 
-        assert_path_equal(path, exp_path)
+        AB = Path.calculate_AB(X_0, X_1)
+
+        exp_x_a = Position(5, 0, 0)
+        exp_x_b = Position(8, 3, 0.5 * pi)
+
+        self.assertEqual(len(AB), 2)
+        assert_position_equal(AB[0], exp_x_a)
+        assert_position_equal(AB[1], exp_x_b)
+    
+    def test_down_left(self):
+        X_0 = Position(4, 5, 1.5 * pi)
+        X_1 = Position(-2, -1, pi)
+
+        AB = Path.calculate_AB(X_0, X_1)
+
+        exp_x_a = Position(4, 2, 1.5 * pi)
+        exp_x_b = Position(1, -1, pi)
+
+        self.assertEqual(len(AB), 2)
+        assert_position_equal(AB[0], exp_x_a)
+        assert_position_equal(AB[1], exp_x_b)
+
+
+class TestPreCalculatePath(unittest.TestCase):
+    def test_straight_path(self):
+        X_0 = Position(0, 0, 0)
+        X_1 = Position(10, 0, 0)
+
+        path = Path.pre_calculate_path(X_0, X_1, 1)
+
+        assert_path_equal(path, [X_1])
+    
+    def test_corner_right_up(self):
+        X_0 = Position(0, 0, 0)
+        X_1 = Position(10, 10, 0.5 * pi)
+        speed = 1
+
+        pre_calculated_path = Path.pre_calculate_path(X_0, X_1, speed)
+
+        exp_n_positions = 13
+        exp_x_a = Position(10 - Path.CORNER_RADIUS, 0, 0.2617)
+        exp_x_b = Position(10, Path.CORNER_RADIUS, 0.5 * pi)
+        exp_x_b_1 = Position(10, Path.CORNER_RADIUS + 1, 0.5 * pi) 
+        exp_x_b_m2 = Position(10, 9, 0.5 * pi)
+
+        self.assertEqual(len(pre_calculated_path), exp_n_positions)
+        assert_position_equal(pre_calculated_path[0], exp_x_a, places=3)
+        assert_position_equal(pre_calculated_path[5], exp_x_b)
+        assert_position_equal(pre_calculated_path[6], exp_x_b_1)
+        assert_position_equal(pre_calculated_path[-2], exp_x_b_m2)
+
 
 
 if __name__ == "__main__":

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -163,7 +163,19 @@ class TestGenerateCorner(unittest.TestCase):
 
         assert_position_equal(corner[1], exp_p_1, places=3)
         assert_position_equal(corner[-2], exp_p_m1, places=3)
-
     
+
+class TestPath(unittest.TestCase):
+    def test_straight_path(self):
+        X_0 = Position(0, 0, 0)
+        X_1 = Position(10, 0, 0)
+
+        path = Path.generate_path(X_0, X_1)
+
+        exp_path = [Position(i, 0, 0) for i in range(11)]
+
+        assert_path_equal(path, exp_path)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -213,6 +213,5 @@ class TestPreCalculatePath(unittest.TestCase):
         assert_position_equal(pre_calculated_path[-2], exp_x_b_m2)
 
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Path should only contain a pre-defined path for the sections that are not prone to interruptions.
Cars in the queue section determine their position dynamically.
After the traffic light, we can use pre-defined paths to reduce computational effort.
Consider calculating these paths upon initialisation.

closes #6 